### PR TITLE
Added missing 'openapi.yml' for kamel run

### DIFF
--- a/02-serverless-api/readme.didact.md
+++ b/02-serverless-api/readme.didact.md
@@ -168,7 +168,7 @@ To run the integration, you need to link it to the proper configuration, that de
 As alternative, to connect the integration to the **test Minio server** deployed before using the [test/MinioCustomizer.java](didact://?commandId=vscode.open&projectFilePath=02-serverless-api/test/MinioCustomizer.java "Opens the customizer file"){.didact} class:
 
 ```
-kamel run API.java --source test/MinioCustomizer.java --property file:test/minio.properties
+kamel run API.java --open-api openapi.yml --source test/MinioCustomizer.java --property file:test/minio.properties
 ```
 ([^ execute](didact://?commandId=vscode.didact.sendNamedTerminalAString&text=camelTerm$$kamel%20run%20API.java%20--source%20test%2FMinioCustomizer.java%20--property%20file%3Atest%2Fminio.properties&completion=Integration%20run. "Opens a new terminal and sends the command above"){.didact})
 
@@ -177,7 +177,7 @@ kamel run API.java --source test/MinioCustomizer.java --property file:test/minio
 To connect the integration to the **AWS S3 service**:
 
 ```
-kamel run API.java --property file:s3.properties
+kamel run API.java --open-api openapi.yml --property file:s3.properties
 ```
 ([^ execute](didact://?commandId=vscode.didact.sendNamedTerminalAString&text=camelTerm$$kamel%20run%20API.java%20--property%20file%3As3.properties&completion=Integration%20run. "Opens a new terminal and sends the command above"){.didact})
 

--- a/02-serverless-api/s3.properties
+++ b/02-serverless-api/s3.properties
@@ -5,11 +5,11 @@
 # Bucket (referenced in the routes)
 api.bucket=camel-k
 # Region of the buket
-camel.component.aws-s3.region=EU_WEST_1
+camel.component.aws2-s3.region=EU_WEST_1
 # AWS Access Key ID
-camel.component.aws-s3.access-key=<put-your-aws-access-key-id-here>
+camel.component.aws2-s3.access-key=<put-your-aws-access-key-id-here>
 # AWS Access Key Secret
-camel.component.aws-s3.secret-key=<put-your-aws-access-key-secret-here>
+camel.component.aws2-s3.secret-key=<put-your-aws-access-key-secret-here>
 
 # General configuration
 camel.context.rest-configuration.api-context-path=/openapi.json


### PR DESCRIPTION
As far as I understand the example lacks the inclusion of the openapi spec. Therefore, I added the missing `--open-api openapi.yml` statement for `kamel run` command. 