### PR TITLE
Improve DNS example

### DIFF
--- a/generic-examples/dns/README.md
+++ b/generic-examples/dns/README.md
@@ -1,3 +1,44 @@
-# DNS Camel K examples
+# DNS queries in Camel K examples
 
-Find useful examples about how to use DNS in a Camel K integration.
+Contains examples on how to perform DNS queries in a Camel K integration.
+
+You can find more information about Apache Camel and Apache Camel K on the [official Camel website](https://camel.apache.org).
+
+## Before you begin
+
+Read the general instructions in the [root README.md file](/README.md) for setting up your environment and the Kubernetes cluster before looking at this example.
+
+Make sure you've read the [installation instructions](https://camel.apache.org/camel-k/latest/installation/installation.html) for your specific
+cluster before starting the example.
+
+## Understanding the Examples
+- [`ip.js`](./ip.js): defines a route that every second, uses a message header to query DNS for an IP address and logs the result.
+- [`lookup.js`](./lookup.js): defines a route that every 10 seconds, uses message headers to lookup the `MX` records associated with a domain name, processes the response and logs it.
+
+To learn about more options for configuring DNS queries, [see here](https://camel.apache.org/components/3.17.x/dns-component.html)
+
+## Running the Examples
+Run the `ip.js` integration:
+```
+kamel run ip.js --dev
+```
+You should see the `IP address` logged to the terminal every second:
+```terminal
+...
+[1] 2022-07-05 09:10:29,983 INFO  [dns] (Camel (camel-1) thread #1 - timer://dns) Exchange[ExchangePattern: InOnly, BodyType: java.net.Inet4Address, Body: 142.251.36.36]
+[1] 2022-07-05 09:10:30,984 INFO  [dns] (Camel (camel-1) thread #1 - timer://dns) Exchange[ExchangePattern: InOnly, BodyType: java.net.Inet4Address, Body: 142.251.36.36]
+```
+
+Run the `lookup.js` integration:
+```
+kamel run lookup.js --dev
+```
+Every 10 seconds, You should see the MX records associated with the specified domain being logged to the terminal. Each MX record should have a `Target` value, a `Priority` value for the target, and a `TTL` value:
+```terminal
+...
+[1] 2022-07-05 09:14:27,803 INFO  [mxrecord] (Camel (camel-1) thread #1 - timer://dns) Target: gmail-smtp-in.l.google.com., Priority: 5, TTL: 30
+[1] 2022-07-05 09:14:27,821 INFO  [mxrecord] (Camel (camel-1) thread #1 - timer://dns) Target: alt2.gmail-smtp-in.l.google.com., Priority: 20, TTL: 30
+[1] 2022-07-05 09:14:27,829 INFO  [mxrecord] (Camel (camel-1) thread #1 - timer://dns) Target: alt4.gmail-smtp-in.l.google.com., Priority: 40, TTL: 30
+[1] 2022-07-05 09:14:27,833 INFO  [mxrecord] (Camel (camel-1) thread #1 - timer://dns) Target: alt3.gmail-smtp-in.l.google.com., Priority: 30, TTL: 30
+[1] 2022-07-05 09:14:27,858 INFO  [mxrecord] (Camel (camel-1) thread #1 - timer://dns) Target: alt1.gmail-smtp-in.l.google.com., Priority: 10, TTL: 30
+```

--- a/generic-examples/dns/ip.js
+++ b/generic-examples/dns/ip.js
@@ -17,16 +17,12 @@
 //
 // To run this integrations use:
 //
-//     kamel run -d camel-dns examples/dns.js
-//
-// Or simply (since dependency auto-detection is enabled by default):
-//
-//     kamel run examples/dns.js
+//     kamel run ip.js
 //
 
 from('timer:dns?period=1000')
-    .routeId('dns')
-    .setHeader('dns.domain')
-        .constant('www.google.com')
-    .to('dns:ip')
-    .to('log:dns');
+  .routeId('dns')
+  .setHeader('dns.domain')
+  .constant('www.google.com')
+  .to('dns:ip')
+  .to('log:dns');

--- a/generic-examples/dns/lookup.js
+++ b/generic-examples/dns/lookup.js
@@ -1,0 +1,34 @@
+// camel-k: language=js
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// To run this integrations use:
+//
+//     kamel run lookup.js --dev
+//
+
+from('timer:dns?period=10000')
+  .routeId('dns')
+  .setHeader('dns.name', constant('gmail.com'))
+  .setHeader('dns.type', constant('MX'))
+  .to('dns:lookup')
+  .split(body())
+  .setBody(
+    simple(
+      'Target: ${body.getTarget}, Priority: ${body.getPriority}, TTL: ${body.getTTL}',
+    ),
+  )
+  .to('log:mxrecord?plain=true');


### PR DESCRIPTION
@tadayosi @Delawen I added a new example that shows how to lookup a `dns` record. I renamed `dns.js` to a more appropriate name. I also added more information to the readme. The examples run fine. What do you think?