### PR TITLE
Add IBM MQ example

### DIFF
--- a/generic-examples/ibm-mq/MQRoute.java
+++ b/generic-examples/ibm-mq/MQRoute.java
@@ -1,0 +1,66 @@
+// camel-k: language=java
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.ibm.mq.jms.MQQueueConnectionFactory;
+import com.ibm.msg.client.wmq.WMQConstants;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.jms.JmsComponent;
+import org.apache.camel.impl.DefaultCamelContext;
+
+public class MQRoute extends RouteBuilder {
+
+    static String mqHost = "10.108.69.161";
+    static int mqPort = 1414;
+    static String mqQueueManager = "QM1";
+    static String mqChannel = "DEV.APP.SVRCONN";
+    static String mqQueue = "DEV.QUEUE.1";
+    static String user = "app";
+    static String password = "ibmmqpasswd";
+
+    @Override
+    public void configure() {
+        MQQueueConnectionFactory mqFactory = createWMQConnectionFactory(mqHost);
+        getContext().getRegistry().bind("mqConnectionFactory", mqFactory);
+        
+        from("timer:tick")
+            .setBody()
+              .simple("Hello Camel K! #${exchangeProperty.CamelTimerCounter}")
+            .to("jms:queue:" + mqQueue + "?connectionFactory=#mqConnectionFactory");
+
+        from("jms:queue:" + mqQueue + "?connectionFactory=#mqConnectionFactory")
+            .to("log:info");
+    }
+
+    private MQQueueConnectionFactory createWMQConnectionFactory(String mqHost) {
+        MQQueueConnectionFactory mqQueueConnectionFactory = new MQQueueConnectionFactory();
+        try {
+            mqQueueConnectionFactory.setHostName(mqHost);
+            mqQueueConnectionFactory.setChannel(mqChannel);
+            mqQueueConnectionFactory.setPort(mqPort);
+            mqQueueConnectionFactory.setQueueManager(mqQueueManager);
+            mqQueueConnectionFactory.setTransportType(WMQConstants.WMQ_CM_CLIENT);
+            mqQueueConnectionFactory.setStringProperty(WMQConstants.USERID, user);
+            mqQueueConnectionFactory.setStringProperty(WMQConstants.PASSWORD, password);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return mqQueueConnectionFactory;
+    }
+}

--- a/generic-examples/ibm-mq/README.md
+++ b/generic-examples/ibm-mq/README.md
@@ -1,0 +1,42 @@
+# Examples showing how to use Camel K to connect to an IBM MQ Server
+
+* Deploy the IBM MQ Server, as describe in the ibm-mq-server-deploy/README.md
+
+* Change the IBM MQ Server address in the MQRoute.java class file
+
+```
+ibmip=`kubectl get svc/ibm-mq-server -ojsonpath="{.spec.clusterIP}"`; sed -i "/mqHost/s/\".*\"/\"$ibmip\"/g" MQRoute.java
+```
+
+For licensing reasons, the IBM MQ Java libraries are not defined in the routes themselves, but you can declare the dependency while running the integration. Alternatively you can use Kamel modeline to add the dependency in the route file as a header.
+
+* Run the MQRoute.java. It is a producer and consumer of messages.
+
+```
+kamel run --dev MQRoute.java -d mvn:com.ibm.mq:com.ibm.mq.allclient:9.2.5.0
+```
+
+It will print the following output in the console
+
+```
+JmsConsumer[DEV.QUEUE.1]) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Hello Camel K! #2]
+```
+
+* If you want to have a more streamlined declarative approach to run the integration using Kamelets, you can use the routes in YAML format.
+
+
+The following kamel commands, has three distincts configurations:
+1. Declare de dependency of IBM MQ Java library as previously mentioned.
+2. Use the IBM MQ Server password set in a kubernetes `Secret` object.
+3. Set the IBM MQ Server IP address as a property to run the integration, so the IBM MQ Cient can connect to the server.
+
+
+Run the integration to generate messages and send them to the IBM MQ Queue (there is no output in the console)
+```
+kamel run --dev jms-ibm-mq-sink-binding.yaml -d mvn:com.ibm.mq:com.ibm.mq.allclient:9.2.5.0 --config secret:ibm-mq/ibm-mq-password -p serverName=`kubectl get svc/ibm-mq-server -ojsonpath="{.spec.clusterIP}"`
+```
+
+Run the integration to retrieve messages from the IBM MQ Queue and print in the console.
+```
+kamel run --dev jms-ibm-mq-source-binding.yaml -d mvn:com.ibm.mq:com.ibm.mq.allclient:9.2.5.0 --config secret:ibm-mq/ibm-mq-password -p serverName=`kubectl get svc/ibm-mq-server -ojsonpath="{.spec.clusterIP}"`
+```

--- a/generic-examples/ibm-mq/README.md
+++ b/generic-examples/ibm-mq/README.md
@@ -1,6 +1,22 @@
 # Examples showing how to use Camel K to connect to an IBM MQ Server
 
-* Deploy the IBM MQ Server, as describe in the ibm-mq-server-deploy/README.md
+The examples show the ways we can connect to an IBM MQ Server using Camel K
+
+You can find more information about Apache Camel and Apache Camel K on the [official Camel website](https://camel.apache.org).
+
+## Before you begin
+
+Read the general instructions in the [root README.md file](/README.md) for setting up your environment and the Kubernetes cluster before looking at this example.
+
+Make sure you've read the [installation instructions](https://camel.apache.org/camel-k/latest/installation/installation.html) for your specific
+cluster before starting the example.
+
+## Additional Requirements for running the examples
+**An IBM MQ Server**: Queue manager for providing queuing services to clients. For installation instructions, see [How to deploy an IBM MQ Server to a Kubernetes cluster](./ibm-mq-server-deploy/) for demo purposes.
+
+## Running the examples
+
+* Deploy the IBM MQ Server, as described in the [ibm-mq-server-deploy/README.md](./ibm-mq-server-deploy/README.md)
 
 * Change the IBM MQ Server address in the MQRoute.java class file
 
@@ -8,7 +24,7 @@
 ibmip=`kubectl get svc/ibm-mq-server -ojsonpath="{.spec.clusterIP}"`; sed -i "/mqHost/s/\".*\"/\"$ibmip\"/g" MQRoute.java
 ```
 
-For licensing reasons, the IBM MQ Java libraries are not defined in the routes themselves, but you can declare the dependency while running the integration. Alternatively you can use Kamel modeline to add the dependency in the route file as a header.
+For licensing reasons, the IBM MQ Java libraries are not defined in the routes themselves, but you can declare the dependency while running the integration. Alternatively, you can use Kamel modeline to add the dependency in the route file as a header.
 
 * Run the MQRoute.java. It is a producer and consumer of messages.
 
@@ -25,10 +41,10 @@ JmsConsumer[DEV.QUEUE.1]) Exchange[ExchangePattern: InOnly, BodyType: String, Bo
 * If you want to have a more streamlined declarative approach to run the integration using Kamelets, you can use the routes in YAML format.
 
 
-The following kamel commands, has three distincts configurations:
-1. Declare de dependency of IBM MQ Java library as previously mentioned.
+The kamel commands below set the following configurations:
+1. As previously mentioned, declare as a dependency, the IBM MQ Java library.
 2. Use the IBM MQ Server password set in a kubernetes `Secret` object.
-3. Set the IBM MQ Server IP address as a property to run the integration, so the IBM MQ Cient can connect to the server.
+3. Set the IBM MQ Server IP address as a property to run the integration, so the IBM MQ Client can connect to the server.
 
 
 Run the integration to generate messages and send them to the IBM MQ Queue (there is no output in the console)

--- a/generic-examples/ibm-mq/ibm-mq-server-deploy/README.md
+++ b/generic-examples/ibm-mq/ibm-mq-server-deploy/README.md
@@ -1,0 +1,26 @@
+# How to deploy a IBM MQ Server to Kubernetes cluster
+
+This is a very simple example to show how to install an IBM MQ Server. **Note**, this is not ready for any production purpose.
+
+The Deployment uses IBM MQ Server image from docker hub.
+
+## Install the IBM MQ Server
+```
+kubectl create -f ibm-mq-server.yaml
+```
+
+This will create a server with the following data:
+
+```
+App User     : app
+App Password : ibmmqpasswd
+Queue manager: QM1
+Queue        : DEV.QUEUE.1
+Channel      : DEV.APP.SVRCONN
+```
+
+## Remove the IBM MQ Server resources
+
+```
+kubectl delete -f ibm-mq-server.yaml
+```

--- a/generic-examples/ibm-mq/ibm-mq-server-deploy/README.md
+++ b/generic-examples/ibm-mq/ibm-mq-server-deploy/README.md
@@ -1,4 +1,4 @@
-# How to deploy a IBM MQ Server to Kubernetes cluster
+# How to deploy an IBM MQ Server to a Kubernetes cluster
 
 This is a very simple example to show how to install an IBM MQ Server. **Note**, this is not ready for any production purpose.
 

--- a/generic-examples/ibm-mq/ibm-mq-server-deploy/ibm-mq-server.yaml
+++ b/generic-examples/ibm-mq/ibm-mq-server-deploy/ibm-mq-server.yaml
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ibm-mq
+type: Opaque
+# password: ibmmqpasswd
+data:
+  ibm-mq-password: aWJtbXFwYXNzd2Q=
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ibm-mq-server
+  labels:
+    app: ibm-mq-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ibm-mq-server
+  template:
+    metadata:
+      labels:
+        app: ibm-mq-server
+    spec:
+      containers:
+        - name: ibm-mq-server
+          image: ibmcom/mq
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 1414
+            - containerPort: 9443
+          env:
+            - name: LICENSE
+              value: "accept"
+            - name:  MQ_QMGR_NAME
+              value: "QM1"
+            - name:  MQ_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ibm-mq
+                  key: ibm-mq-password
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ibm-mq-server
+  name: ibm-mq-server
+spec:
+  ports:
+  - name: port-1
+    port: 1414
+    protocol: TCP
+    targetPort: 1414
+  - name: port-2
+    port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: ibm-mq-server
+  type: ClusterIP

--- a/generic-examples/ibm-mq/jms-ibm-mq-sink-binding.yaml
+++ b/generic-examples/ibm-mq/jms-ibm-mq-sink-binding.yaml
@@ -1,0 +1,18 @@
+- route:
+    from:
+      uri: "kamelet:timer-source"
+      parameters:
+        period: 1000
+        message: "Hello Camel K to IBM MQ"
+    steps:
+      - to:
+          uri: "kamelet:jms-ibm-mq-sink"
+          parameters:
+            serverName: "{{serverName}}"
+            serverPort: "1414"
+            destinationType: "queue"
+            destinationName: "DEV.QUEUE.1"
+            queueManager: QM1
+            channel: DEV.APP.SVRCONN
+            username: app
+            password: "{{ibm-mq-password}}"

--- a/generic-examples/ibm-mq/jms-ibm-mq-source-binding.yaml
+++ b/generic-examples/ibm-mq/jms-ibm-mq-source-binding.yaml
@@ -1,0 +1,15 @@
+- route:
+    from:
+      uri: "kamelet:jms-ibm-mq-source"
+      parameters:
+        serverName: "{{serverName}}"
+        serverPort: "1414"
+        destinationType: "queue"
+        destinationName: "DEV.QUEUE.1"
+        queueManager: QM1
+        channel: DEV.APP.SVRCONN
+        username: app
+        password: "{{ibm-mq-password}}"
+    steps:
+      - to:
+          uri: kamelet:log-sink


### PR DESCRIPTION
@tadayosi @Claudio4j @Delawen I made a few additions to the Readme. The integration in `MQRoute.java` runs fine and interacts in the expected way with the IBM mq server. However, `jms-ibm-mq-sink-binding.yaml` and `jms-ibm-mq-source-binding.yaml` use kamelets that are not in the Kamelet catalog version used by Camel K, so the declarative approach to running the integration doesn't work atm. Wdyt?