### PR TITLE
Refactor Container trait generic example and add Health trait

### DIFF
--- a/generic-examples/README.md
+++ b/generic-examples/README.md
@@ -54,4 +54,5 @@ Traits configuration will be very helpful to fine tune your `Integration`. Here 
 | Type  |  Description | Link  |
 |---|---|---|
 | Container | How to customize with `container` trait| [see examples](./traits/container/)|
+| Health | How to customize with `health` trait| [see examples](./traits/health/)|
 | JVM | How to use `jvm` trait| [see examples](./traits/jvm/)|

--- a/generic-examples/traits/container/Container.java
+++ b/generic-examples/traits/container/Container.java
@@ -15,28 +15,21 @@
  * limitations under the License.
  */
 
-// Generate a certificate for the integration (provide at least Country Name, can use defaults for rest)
-// openssl req -x509 -newkey rsa:4096 -keyout /tmp/integration-key.pem -out /tmp/integration-cert.pem -days 365 -nodes
-
-// Create a secret containing the generated certificate
-// kubectl create secret tls my-tls-secret --cert=/tmp/integration-cert.pem --key=/tmp/integration-key.pem
-
 // Run the integration
 /*
 kamel run \
-  --property quarkus.http.ssl.certificate.file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.crt \
-  --property quarkus.http.ssl.certificate.key-file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.key \
-  --config secret:my-tls-secret \
-  HttpsHealthChecks.java \
-  --trait container.port=8443 \
-  --trait container.probes-enabled=true \
-  --trait container.liveness-scheme=HTTPS \
-  --trait container.readiness-scheme=HTTPS
+  --name container \
+  Container.java \
+  --trait container.image-pull-policy=Always \
+  --trait container.request-cpu=0.005 \
+  --trait container.limit-cpu=0.2 \
+  --trait container.request-memory=100Mi \
+  --trait container.limit-memory=500Mi
 */
 
 import org.apache.camel.builder.RouteBuilder;
 
-public class HttpsHealthChecks extends RouteBuilder {
+public class Container extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("timer:tick")

--- a/generic-examples/traits/container/README.md
+++ b/generic-examples/traits/container/README.md
@@ -1,3 +1,112 @@
 # Camel K Container Trait
 
 In this section you will find examples about fine tuning your `Integration` using **Container** `trait` capability.
+
+The Container trait is a  platform trait, it is **enabled** by default.
+
+## Before you begin
+
+Read the general instructions in the [root README.md file](../../README.md) for setting up your environment and the Kubernetes cluster before looking at this example.
+
+Make sure you've read the [installation instructions](https://camel.apache.org/camel-k/latest/installation/installation.html) for your specific cluster before starting the example.
+
+## Basic usage
+
+To configure some custom values, run the integration
+
+```sh
+kamel run \
+  --name container \
+  Container.java \
+  --trait container.image-pull-policy=Always \
+  --trait container.request-cpu=0.005 \
+  --trait container.limit-cpu=0.2 \
+  --trait container.request-memory=100Mi \
+  --trait container.limit-memory=500Mi
+```
+
+
+
+When you check the values declared by the pod spec
+```sh
+kubectl get pods --selector="camel.apache.org/integration"="container" -o yaml
+```
+
+You should get a result with the values you defined
+
+```yaml
+...
+                "imagePullPolicy": "Always",
+
+...
+                "resources": {
+                    "limits": {
+                        "cpu": "200m",
+                        "memory": "500Mi"
+                    },
+                    "requests": {
+                        "cpu": "5m",
+                        "memory": "100Mi"
+                    }
+                },
+...
+```
+
+## Advanced usages
+
+The container and service port configuration needs needs the presence of a service, else it will be ignored.
+
+For these example, we use an example route exposing some rest endpoint. This will enable the service and expose the container port by default.
+
+> **Warning**
+> 
+> Be careful when changing the default ports value and/or name as it can have some side effects.
+
+### Service Port
+
+To define a custom service port, run the integration
+
+```sh
+kamel run --name restcontainer \
+  RestDSL.java \
+  --trait service.enabled=true \
+  --trait container.service-port=8082 \
+  --trait container.service-port-name=myserviceport
+```
+When you check the values declared by the service spec
+
+```sh
+kubectl get service restcontainer  -o jsonpath='{.spec.ports}'
+```
+
+You should get a result with the values you defined
+
+```json
+[{"name":"myserviceport","port":8082,"protocol":"TCP","targetPort":"http"}]
+```
+
+For more details on the Service trait, see the [example README.md file](../service/README.md)
+
+### Container Port
+
+The definition of a custom container port need some modification of quarkus default property to be effective.
+
+```sh
+kamel run \
+  --property quarkus.http.port=8081 \
+  --name restcontainer \
+  RestDSL.java \
+  --trait container.port=8081 \
+  --trait container.port-name=mycontainerport
+```
+
+```sh
+kubectl get pods --selector="camel.apache.org/integration"="restcontainer" \
+    -o jsonpath= -o jsonpath='{.items[*].spec.containers[*].ports}'
+```
+
+You should get a result with the values you defined
+
+```json
+[{"containerPort":8081,"name":"mycontainerport","protocol":"TCP"}]
+```

--- a/generic-examples/traits/container/RestDSL.java
+++ b/generic-examples/traits/container/RestDSL.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.Exchange;
+
+public class RestDSL extends org.apache.camel.builder.RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        rest()
+            .get("/hello")
+            .to("direct:hello");
+
+        from("direct:hello")
+            .setHeader(Exchange.CONTENT_TYPE, constant("text/plain"))
+            .transform().simple("Hello World");
+    }
+}

--- a/generic-examples/traits/health/HealthChecks.java
+++ b/generic-examples/traits/health/HealthChecks.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class HealthChecks extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("timer:tick")
+            .setBody()
+            .constant("Hello Camel K!")
+            .to("log:info");
+    }
+}

--- a/generic-examples/traits/health/README.md
+++ b/generic-examples/traits/health/README.md
@@ -1,0 +1,80 @@
+# Camel K Health Trait
+
+In this section you will find examples about fine tuning your `Integration` using **Health** `trait` capability.
+
+The Health trait can be used to activate and configure the Health Probes on the integration container.
+
+## Before you begin
+
+Read the general instructions in the [root README.md file](../../README.md) for setting up your environment and the Kubernetes cluster before looking at this example.
+
+Make sure you've read the [installation instructions](https://camel.apache.org/camel-k/latest/installation/installation.html) for your specific cluster before starting the example.
+
+## Basic usage
+
+By default the trait is disabled so it needs to be activated.
+
+To activate the trait and configure the liveness Probes, run the integration
+
+```sh
+kamel run \
+    --name=health \
+    HealthChecks.java \
+    --trait health.enabled=true \
+    --trait health.liveness-probe-enabled=true \
+    --trait health.liveness-initial-delay=30 \
+    --trait health.liveness-period=10 \
+    --trait health.liveness-failure-threshold=5 \
+    --trait health.liveness-success-threshold=1 \
+    --trait health.liveness-timeout=2
+```
+
+
+When you check the values declared by the pod spec
+```sh
+kubectl get pods --selector="camel.apache.org/integration"="health" -o jsonpath='{.items[*].spec.containers[*].livenessProbe}'
+```
+
+You should get a result with the values you defined
+```json
+{"failureThreshold":5,"httpGet":{"path":"/q/health/live","port":8080,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":2}
+```
+
+## Probes with HTTPS scheme
+
+Generate a certificate for the integration (provide at least Country Name, can use defaults for rest)
+```sh
+openssl req -x509 -newkey rsa:4096 -keyout /tmp/integration-key.pem -out /tmp/integration-cert.pem -days 365 -nodes
+```
+
+Create a secret containing the generated certificate
+```sh
+kubectl create secret tls my-tls-secret --cert=/tmp/integration-cert.pem --key=/tmp/integration-key.pem
+```
+
+Run the integration
+ ```sh
+ kamel run \
+    --property quarkus.http.ssl.certificate.file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.crt \
+    --property quarkus.http.ssl.certificate.key-file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.key \
+    --config secret:my-tls-secret \
+    --pod-template patch_probe.yaml \
+    --name health \
+    HealthChecks.java \
+    --trait health.enabled=true \
+    --trait health.liveness-probe-enabled=true \
+    --trait health.liveness-scheme=HTTPS \
+    --trait health.readiness-probe-enabled=true \
+    --trait health.readiness-scheme=HTTPS
+```
+
+
+When you check the values declared by the pod spec for the readinessProbe
+```sh
+kubectl get pods --selector="camel.apache.org/integration"="health" -o jsonpath='{.items[*].spec.containers[*].readinessProbe}'
+```
+
+You should get a result with the scheme you defined
+```json
+{"failureThreshold":3,"httpGet":{"path":"/q/health/ready","port":8443,"scheme":"HTTPS"},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}
+```

--- a/generic-examples/traits/health/patch_probe.yaml
+++ b/generic-examples/traits/health/patch_probe.yaml
@@ -1,0 +1,8 @@
+containers:
+  - name: integration
+    readinessProbe:
+      httpGet:
+        port: 8443
+    livenessProbe:
+      httpGet:
+        port: 8443


### PR DESCRIPTION
This is an update of the `container` trait  example taking into account the creation of "trait health".

* `container` trait example has been updated with the current behavior as of camel k 1.10
* `health` trait has been added with the current behavior as of camel k 1.10 (with this issue apache/camel-k/issues/3877 still open)
