### PR TITLE
Remove route() from rest example

### DIFF
--- a/generic-examples/rest/routes-rest.js
+++ b/generic-examples/rest/routes-rest.js
@@ -23,5 +23,7 @@
 rest('/say/hello')
     .produces("text/plain")
     .get()
-        .route()
-        .transform().constant("Hello World");
+    .to('direct:sayHello');
+
+from('direct:sayHello')
+    .transform().constant("Hello World");


### PR DESCRIPTION
Removed obsolete `route()`, also viz https://github.com/apache/camel-k/pull/4854