### PR TITLE
refactor: added query param includeMetadata

### DIFF
--- a/generic-examples/saga/Saga.java
+++ b/generic-examples/saga/Saga.java
@@ -30,7 +30,7 @@ public class Saga extends RouteBuilder {
 		service.setLocalParticipantUrl("http://saga");
 		getContext().addService(service);
 
-		from("timer:clock?period=5000")
+		from("timer:clock?period=5000&includeMetadata=true")
 			.saga()
 			.setHeader("id", header(Exchange.TIMER_COUNTER))
 			.setHeader(Exchange.HTTP_METHOD, constant("POST"))


### PR DESCRIPTION
The saga example was not including the #`order-number`. I suspect that in a earlier version of the timer component the flag `includeMetada` was set to `true` by default, but on the current versions it comes as false. By including that flag as true the number is now returned.

Example:
`2025-04-16 14:45:58,693 INFO  [source] (Thread-2184) Paying train for order #2305`